### PR TITLE
Specify name of output txt file

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ DDDDDDDDD,HLA-C*0702
 Then you run:
 
 ```shell
-python3 deepimmuno-cnn.py --mode "multiple" --intdir "/path/to/above/file" --outdir "/path/to/output/folder"
+python3 deepimmuno-cnn.py --mode "multiple" --intdir "/path/to/above/file" --outdir "/path/to/output/folder --outname "outname.txt"
 ```
 
 - *Please note, when you specify the output dir, don't include the forward slash at the end, for example, use "/Desktop" instead "/Desktop/"*
@@ -69,7 +69,7 @@ A full help prompt is as below:
 
 ```
 usage: deepimmuno-cnn.py [-h] [--mode MODE] [--epitope EPITOPE] [--hla HLA]
-                         [--intdir INTDIR] [--outdir OUTDIR]
+                         [--intdir INTDIR] [--outdir OUTDIR] [--outname OUTNAME]
 
 DeepImmuno-CNN command line
 
@@ -80,6 +80,7 @@ optional arguments:
   --hla HLA          if single mode, specifying your HLA allele
   --intdir INTDIR    if multiple mode, specifying the path to your input file
   --outdir OUTDIR    if multiple mode, specifying the path to your output folder
+  --outname OUTNAME  if multiple mode, specifying the name of the output file
 ```
 
 ## DeepImmuno-GAN

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ DDDDDDDDD,HLA-C*0702
 Then you run:
 
 ```shell
-python3 deepimmuno-cnn.py --mode "multiple" --intdir "/path/to/above/file" --outdir "/path/to/output/folder --outname "outname.txt"
+python3 deepimmuno-cnn.py --mode "multiple" --intdir "/path/to/above/file" --outdir "/path/to/output/folder" --outname "outname.txt"
 ```
 
 - *Please note, when you specify the output dir, don't include the forward slash at the end, for example, use "/Desktop" instead "/Desktop/"*

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # DeepImmuno
 Deep-learning empowered prediction and generation of immunogenic epitopes for T cell immunity. 
 
-We recommend to try out our web application for that: https://deepimmuno.herokuapp.com/
+We recommend to try out our web application for that: https://deepimmuno.research.cchmc.org/
 
 The repository for building the DeepImmuno web server: https://github.com/frankligy/DeepImmuno-web
 

--- a/deepimmuno-cnn.py
+++ b/deepimmuno-cnn.py
@@ -190,7 +190,7 @@ def computing_s(peptide,mhc):
     return float(scoring)
 
 
-def file_process(upload,download):
+def file_process(upload,download,result_file='deepimmuno-cnn-result.txt'):
 
     after_pca = np.loadtxt('./data/after_pca.txt')
     hla = pd.read_csv('./data/hla2paratopeTable_aligned.txt',sep='\t')
@@ -211,7 +211,7 @@ def file_process(upload,download):
     scoring = cnn_model.predict(x=[input1_score, input2_score])
     scoring = cnn_model.predict(x=[input1_score, input2_score])
     ori_score['immunogenicity'] = scoring
-    ori_score.to_csv(os.path.join(download,'deepimmuno-cnn-result.txt'), sep='\t', index=None)
+    ori_score.to_csv(os.path.join(download,result_file), sep='\t', index=None)
 
 def main(args):
     mode = args.mode
@@ -229,7 +229,9 @@ def main(args):
         print("input file is {}".format(intFile))
         outFolder = args.outdir
         print("output will be in {}".format(outFolder))
-        file_process(intFile,outFolder)
+        outName = args.outname
+        print("output name will be {}".format(outName))
+        file_process(intFile,outFolder,outName)
 
 
 if __name__ == '__main__':
@@ -239,5 +241,6 @@ if __name__ == '__main__':
     parser.add_argument('--hla',type=str,default=None,help='if single mode, specifying your HLA allele')
     parser.add_argument('--intdir',type=str,default=None,help='if multiple mode, specifying the path to your input file')
     parser.add_argument('--outdir',type=str,default=None,help='if multiple mode, specifying the path to your output folder')
+    parser.add_argument('--outname',type=str,default='deepimmuno-cnn-result.txt',help='specify the name of the output txt file. Default: deepimmuno-cnn-result.txt')
     args = parser.parse_args()
     main(args)


### PR DESCRIPTION
Hi! Thanks for the awesome tool.
I modified deepimmuno-cnn.py to be able to specify the output name. This is convenient in case one wants to run deepimmuno multiple times in the same directory. 
Cheers